### PR TITLE
Linking liftoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following inspections are included:
 * Using outdated versions of LibGDX and related libraries \[1]
 * Declaring a combination of minSdkVersion, maxSdkVersion, targetSdkVersion and &lt;support-screens&gt; which excludes the App from being listed as "Designed for Tablets" in the Google Play Store \[1]
 
-\[1]: These inspections assume the project uses a fairly standard setup, like those created by `gdx-setup` and [`gdx-setup`](https://github.com/czyzby/gdx-setup).
+\[1]: These inspections assume the project uses a fairly standard setup, like those created by `gdx-setup` and [`gdx-liftoff`](https://github.com/tommyettinger/gdx-liftoff).
 
 ## Color previews
 When using a LibGDX color in Java or Kotlin code (e.g. `Color.BLUE` or `Color.valueOf("#0000ff")`) a preview of the the color is shown in the left gutter.


### PR DESCRIPTION
The community-made `gdx-setup` is "deprecated" and itself recommends using `liftoff`.