### PR TITLE
Make atlas preview images sharp when scaled up

### DIFF
--- a/src/main/kotlin/com/gmail/blueboxware/libgdxplugin/ui/ImagePreviewDocumentationTarget.kt
+++ b/src/main/kotlin/com/gmail/blueboxware/libgdxplugin/ui/ImagePreviewDocumentationTarget.kt
@@ -39,6 +39,7 @@ import com.intellij.platform.backend.presentation.TargetPresentation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.createSmartPointer
 import com.intellij.util.ui.ImageUtil
+import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.net.URI
 import java.net.URISyntaxException
@@ -135,7 +136,16 @@ class ImagePreviewDocumentationTarget(private val targetElement: PsiElement?) : 
             }
         }
 
-        val previewImage = ImageUtil.toBufferedImage(ImageUtil.scaleImage(image, scale.toDouble()))
+        // Scale the image without smoothing to keep pixel art sharp
+        val previewImage = BufferedImage(image.width * scale, image.height * scale, BufferedImage.TYPE_INT_ARGB)
+        previewImage.createGraphics().apply {
+            setRenderingHint(
+                RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
+            drawImage(image, 0, 0, previewImage.width, previewImage.height, null)
+            dispose()
+        }
+
         val imageFile = FileUtil.createTempFile("img", ".png", true)
         try {
             ImageIO.write(previewImage, "png", imageFile)

--- a/src/main/kotlin/com/gmail/blueboxware/libgdxplugin/ui/ImagePreviewDocumentationTarget.kt
+++ b/src/main/kotlin/com/gmail/blueboxware/libgdxplugin/ui/ImagePreviewDocumentationTarget.kt
@@ -38,7 +38,6 @@ import com.intellij.platform.backend.documentation.DocumentationTarget
 import com.intellij.platform.backend.presentation.TargetPresentation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.createSmartPointer
-import com.intellij.util.ui.ImageUtil
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.net.URI


### PR DESCRIPTION
The previews for small images in atlas files were blurry when scaled up due to ImageUtil's internal handling.

This change displays the images scaled sharply, so that the art can be previewed accurately.

Tested by building and installing the plugin locally into IntelliJ IDEA, then previewing the test files in the LibGDXPlugin repo.

<img width="1054" height="614" alt="idea64_vDiKL8JGsw" src="https://github.com/user-attachments/assets/9341e5c8-f226-41e3-bcbc-81a0d56a0d7a" />
